### PR TITLE
Clean up auto scrolling to current time

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a MIT-style license
 // that can be found in the LICENSE file.
 
-import 'package:flutter/scheduler.dart';
-
 import 'non_working_time.dart';
 import 'package:flutter/material.dart';
 
@@ -180,18 +178,6 @@ class InternalDayViewPage<T extends Object?> extends StatefulWidget {
 class _InternalDayViewPageState<T extends Object?>
     extends State<InternalDayViewPage<T>> {
   ScrollController? _scrollController;
-
-  @override
-  void initState() {
-    // Auto scroll to current time after building widget
-
-    if (widget.initialScrollOffset == null) {
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => scrollToCurrentTime());
-    }
-
-    super.initState();
-  }
 
   @override
   void didChangeDependencies() {


### PR DESCRIPTION
# Description

Clean up auto scrolling to current time. Because we can get correct top and bottom padding for pre-scrolling to current time. Therefore, no need to scroll anymore when start the app.



## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_calendar_view/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org